### PR TITLE
fix: reload bug

### DIFF
--- a/agent.js
+++ b/agent.js
@@ -12,7 +12,10 @@ module.exports = class AgentBootHook {
   constructor(agent) {
     this.agent = agent;
     this.logger = agent.logger;
-    this.filePath = path.resolve(agent.config.rundir, agent.config.remoteConfig.savePath);
+    this.filePath = path.resolve(
+      agent.config.rundir,
+      agent.config.remoteConfig.savePath
+    );
   }
 
   async willReady() {
@@ -20,14 +23,21 @@ module.exports = class AgentBootHook {
 
     /* istanbul ignore else */
     if (handler) {
-      this.logger.info(`[RemoteConfig] loading remote config and save to ${this.filePath}`);
+      this.logger.info(
+        `[RemoteConfig] loading remote config and save to ${this.filePath}`
+      );
       const result = await handler(this.agent);
       await mkdirp(path.dirname(this.filePath), { recursive: true });
-      await writeFile(this.filePath, JSON.stringify(result || /* istanbul ignore next */{}, null, 2), 'utf-8');
+      await del(this.filePath);
+      await writeFile(
+        this.filePath,
+        JSON.stringify(result || /* istanbul ignore next */ {}, null, 2),
+        'utf-8'
+      );
     }
   }
 
-  async serverDidReady() {
-    await del(this.filePath);
+  beforeClose() {
+    del(this.filePath);
   }
 };

--- a/agent.js
+++ b/agent.js
@@ -12,10 +12,7 @@ module.exports = class AgentBootHook {
   constructor(agent) {
     this.agent = agent;
     this.logger = agent.logger;
-    this.filePath = path.resolve(
-      agent.config.rundir,
-      agent.config.remoteConfig.savePath
-    );
+    this.filePath = path.resolve(agent.config.rundir, agent.config.remoteConfig.savePath);
   }
 
   async willReady() {
@@ -23,21 +20,15 @@ module.exports = class AgentBootHook {
 
     /* istanbul ignore else */
     if (handler) {
-      this.logger.info(
-        `[RemoteConfig] loading remote config and save to ${this.filePath}`
-      );
+      this.logger.info(`[RemoteConfig] loading remote config and save to ${this.filePath}`);
       const result = await handler(this.agent);
       await mkdirp(path.dirname(this.filePath), { recursive: true });
       await del(this.filePath);
-      await writeFile(
-        this.filePath,
-        JSON.stringify(result || /* istanbul ignore next */ {}, null, 2),
-        'utf-8'
-      );
+      await writeFile(this.filePath, JSON.stringify(result || /* istanbul ignore next */ {}, null, 2), 'utf-8');
     }
   }
 
-  beforeClose() {
-    del(this.filePath);
+  async beforeClose() {
+    await del(this.filePath);
   }
 };

--- a/test/fixtures/example/app/controller/test.js
+++ b/test/fixtures/example/app/controller/test.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const { Controller } = require('egg');
+
+class TestController extends Controller {
+  async index() {
+    const data = {
+      foo: this.config.foo,
+      sub: this.config.sub,
+    };
+    this.ctx.body = data;
+  }
+}
+
+module.exports = TestController;

--- a/test/fixtures/example/app/router.js
+++ b/test/fixtures/example/app/router.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports = app => {
+  const { router, controller } = app;
+  router.get('/config', controller.test.index);
+};

--- a/test/remote-config.test.js
+++ b/test/remote-config.test.js
@@ -5,6 +5,7 @@ const assert = require('assert');
 const asserFile = require('assert-file');
 const path = require('path');
 const { rimraf, sleep } = require('mz-modules');
+const request = require('supertest');
 
 describe('test/remote-config.test.js', () => {
   let app;
@@ -24,7 +25,7 @@ describe('test/remote-config.test.js', () => {
     assert(app.config.sub.a === 'b');
     // for win
     await sleep('1s');
-    asserFile.fail(path.join(app.config.rundir, 'remote_config.json'));
+    asserFile(path.join(app.config.rundir, 'remote_config.json'));
 
     // make sure test-plugin is load before remote-config
     const plugins = app.loader.orderPlugins.map(it => it.name);
@@ -35,5 +36,32 @@ describe('test/remote-config.test.js', () => {
     // then check test-plugin use the newest config from remote-config
     assert(app.test.foo === 'egg-remote-config');
     assert(app.test.sub.a === 'b');
+  });
+});
+
+describe('app worker reload', () => {
+  let app;
+  before(async () => {
+    app = mock.cluster({
+      baseDir: 'example',
+      workers: 4,
+    });
+    await app.ready();
+  });
+
+  after(() => app.close());
+
+  it('should ok after reload', async () => {
+    const res = await request(app.callback()).get('/config').expect(200);
+    assert(res.body.foo === 'egg-remote-config');
+    assert(res.body.sub.a === 'b');
+    app.process.send({
+      to: 'master',
+      action: 'reload-worker',
+    });
+    await sleep(20000);
+    const res2 = await request(app.callback()).get('/config').expect(200);
+    assert(res2.body.foo === 'egg-remote-config');
+    assert(res2.body.sub.a === 'b');
   });
 });

--- a/test/remote-config.test.js
+++ b/test/remote-config.test.js
@@ -5,7 +5,6 @@ const assert = require('assert');
 const asserFile = require('assert-file');
 const path = require('path');
 const { rimraf, sleep } = require('mz-modules');
-const request = require('supertest');
 
 describe('test/remote-config.test.js', () => {
   let app;
@@ -52,7 +51,7 @@ describe('app worker reload', () => {
   after(() => app.close());
 
   it('should ok after reload', async () => {
-    const res = await request(app.callback()).get('/config').expect(200);
+    const res = await app.httpRequest().get('/config').expect(200);
     assert(res.body.foo === 'egg-remote-config');
     assert(res.body.sub.a === 'b');
     app.process.send({
@@ -60,7 +59,7 @@ describe('app worker reload', () => {
       action: 'reload-worker',
     });
     await sleep(20000);
-    const res2 = await request(app.callback()).get('/config').expect(200);
+    const res2 = await app.httpRequest().get('/config').expect(200);
     assert(res2.body.foo === 'egg-remote-config');
     assert(res2.body.sub.a === 'b');
   });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
for this issue [no such file or directory](https://github.com/atian25/egg-remote-config/issues/4)

origin version will delete `remote_config.json` when serverDidReady, which will cause bug when app reloaded at `dev` for file modification and at `prod` for app dead accidentally, due to lack of remote config file.

this pr run `del` before write in agent's `willReady` and agent's `beforeClose`